### PR TITLE
Updates of vertexing and LCFIPlus (esp. keep trace of indices)

### DIFF
--- a/analyzers/dataframe/FCCAnalyses/VertexFinderLCFIPlus.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexFinderLCFIPlus.h
@@ -50,6 +50,7 @@ namespace VertexFinderLCFIPlus{
    *  SV finding done before jet clustering
    */
   ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> get_SV_event( ROOT::VecOps::RVec<edm4hep::TrackState> np_tracks,
+                                                                      ROOT::VecOps::RVec<edm4hep::TrackState> thetracks,
 								      VertexingUtils::FCCAnalysesVertex PV,
 								      bool V0_rej=true,
 								      double chi2_cut=9., double invM_cut=10., double chi2Tr_cut=5. ) ;
@@ -82,6 +83,7 @@ namespace VertexFinderLCFIPlus{
    *  default values of thresholds for the constraints are set
    */
   ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks( ROOT::VecOps::RVec<edm4hep::TrackState> tracks_fin,
+                                                                          const ROOT::VecOps::RVec<edm4hep::TrackState>& alltracks,
 									  VertexingUtils::FCCAnalysesVertex PV,
 									  double chi2_cut=9., double invM_cut=10., double chi2Tr_cut=5.) ;
 

--- a/analyzers/dataframe/FCCAnalyses/VertexFitterSimple.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexFitterSimple.h
@@ -45,6 +45,12 @@ namespace VertexFitterSimple{
 						      double sigmax=0., double sigmay=0., double sigmaz=0.,
                                                       double bsc_x=0., double bsc_y=0., double bsc_z=0. )  ;
 
+  VertexingUtils::FCCAnalysesVertex  VertexFitter_Tk( int Primary, ROOT::VecOps::RVec<edm4hep::TrackState> tracks,
+                                                      const ROOT::VecOps::RVec<edm4hep::TrackState>& alltracks,
+                                                      bool BeamSpotConstraint = false,
+                                                      double sigmax=0., double sigmay=0., double sigmaz=0.,
+                                                      double bsc_x=0., double bsc_y=0., double bsc_z=0. )  ;
+
 /// Return the tracks that are flagged as coming from the primary vertex
   ROOT::VecOps::RVec<edm4hep::TrackState> get_PrimaryTracks( VertexingUtils::FCCAnalysesVertex  initialVertex,
                                                                         ROOT::VecOps::RVec<edm4hep::TrackState> tracks,

--- a/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
+++ b/analyzers/dataframe/FCCAnalyses/VertexingUtils.h
@@ -30,7 +30,7 @@ namespace VertexingUtils{
     edm4hep::VertexData vertex;
     int ntracks;
     int mc_ind; ///index in the MC vertex collection if any
-    ROOT::VecOps::RVec<int> reco_ind;
+    ROOT::VecOps::RVec<int> reco_ind;      // indices of the tracks fitted to that vertex, in the collection of all tracks
     ROOT::VecOps::RVec<float> reco_chi2;
     ROOT::VecOps::RVec< TVector3 >  updated_track_momentum_at_vertex;
     ROOT::VecOps::RVec< TVectorD >  updated_track_parameters;
@@ -95,8 +95,15 @@ namespace VertexingUtils{
    /// Retrieve the tracks indices from FCCAnalysesVertex
   ROOT::VecOps::RVec<int> get_VertexRecoInd( FCCAnalysesVertex TheVertex ) ;
 
+  /// Retrieve the indices of the tracks fitted to that vertex, but now in the collection of RecoParticles
+  ROOT::VecOps::RVec<int> get_VertexRecoParticlesInd( FCCAnalysesVertex TheVertex, 
+						      const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& reco );
+ 
   /// Return the number of tracks in a given track collection
   int get_nTracks(ROOT::VecOps::RVec<edm4hep::TrackState> tracks);
+
+  /// compare two track states
+  bool compare_Tracks( const edm4hep::TrackState& tr1, const edm4hep::TrackState& tr2 ) ;
 
   ///////////////////////////////////////////////////
   /// functions used for SV reconstruction

--- a/analyzers/dataframe/src/ReconstructedParticle2Track.cc
+++ b/analyzers/dataframe/src/ReconstructedParticle2Track.cc
@@ -339,7 +339,7 @@ hasTRK( ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData> in ) {
   result.reserve( in.size() );
   
   for (auto & p: in) {
-    if (p.tracks_begin >= 0) result.push_back(true) ;
+    if (p.tracks_begin >= 0 && p.tracks_begin != p.tracks_end) result.push_back(true) ;
     else result.push_back(false);
   }
  return result ;

--- a/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
+++ b/analyzers/dataframe/src/VertexFinderLCFIPlus.cc
@@ -62,7 +62,7 @@ ROOT::VecOps::RVec<ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex>> get_SV
     }
     
     // start finding SVs
-    ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> i_result = findSVfromTracks(tracks_fin, PV, chi2_cut, invM_cut, chi2Tr_cut);
+    ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> i_result = findSVfromTracks(tracks_fin, thetracks, PV, chi2_cut, invM_cut, chi2Tr_cut);
     //
     result.push_back(i_result);
     
@@ -116,7 +116,7 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> get_SV_event(ROOT::VecOps:
   //if(debug_me) std::cout << "tracks_fin.size() = " << tracks_fin.size() << std::endl;
 
   // start finding SVs (only if there are 2 or more tracks)
-  result = findSVfromTracks(tracks_fin, PV, chi2_cut, invM_cut, chi2Tr_cut);
+  result = findSVfromTracks(tracks_fin, thetracks, PV, chi2_cut, invM_cut, chi2Tr_cut);
 
   //if(debug_me) std::cout<<"no more SVs can be reconstructed"<<std::endl;
   
@@ -124,6 +124,7 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> get_SV_event(ROOT::VecOps:
 }
 
 ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> get_SV_event(ROOT::VecOps::RVec<edm4hep::TrackState> np_tracks,
+                                                                   ROOT::VecOps::RVec<edm4hep::TrackState> thetracks,
 								   VertexingUtils::FCCAnalysesVertex PV,
 								   bool V0_rej,
 								   double chi2_cut, double invM_cut, double chi2Tr_cut) {
@@ -142,7 +143,7 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> get_SV_event(ROOT::VecOps:
   }
 
   // start finding SVs (only if there are 2 or more tracks)
-  result = findSVfromTracks(tracks_fin, PV, chi2_cut, invM_cut, chi2Tr_cut);
+  result = findSVfromTracks(tracks_fin, thetracks, PV, chi2_cut, invM_cut, chi2Tr_cut);
   
   return result;
 }
@@ -271,6 +272,7 @@ ROOT::VecOps::RVec<edm4hep::TrackState> V0rejection_tight(ROOT::VecOps::RVec<edm
 }
 
 ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::VecOps::RVec<edm4hep::TrackState> tracks_fin,
+                                                                       const ROOT::VecOps::RVec<edm4hep::TrackState>&  alltracks,
 								       VertexingUtils::FCCAnalysesVertex PV,
 								       double chi2_cut, double invM_cut, double chi2Tr_cut) {
 
@@ -302,7 +304,7 @@ ROOT::VecOps::RVec<VertexingUtils::FCCAnalysesVertex> findSVfromTracks(ROOT::Vec
       tr_vtx_fin.push_back(tracks_fin[i_tr]);
       if(debug_me) std::cout << "Pushing back tracks_fin[i_tr]" << std::endl;
     }
-    VertexingUtils::FCCAnalysesVertex sec_vtx = VertexFitterSimple::VertexFitter_Tk(2, tr_vtx_fin); // flag 2 for SVs
+    VertexingUtils::FCCAnalysesVertex sec_vtx = VertexFitterSimple::VertexFitter_Tk(2, tr_vtx_fin, alltracks); // flag 2 for SVs
 
     // see if we can also get indices in the reco collection (for tracks forming an SV)
     //sec_vtx.reco_ind = VertexFitterSimple::get_reco_ind(recoparticles,thetracks); // incorrect

--- a/analyzers/dataframe/src/VertexFitterSimple.cc
+++ b/analyzers/dataframe/src/VertexFitterSimple.cc
@@ -304,6 +304,7 @@ VertexingUtils::FCCAnalysesVertex  VertexFitter( int Primary,
 
   //FCCAnalysesVertex thevertex = VertexFitter_Tk( Primary, tracks, thetracks) ;
   thevertex = VertexFitter_Tk( Primary, tracks,
+                               thetracks,
 			       BeamSpotConstraint, bsc_sigmax, bsc_sigmay, bsc_sigmaz, bsc_x, bsc_y, bsc_z );
 
   //fill the indices of the tracks
@@ -323,9 +324,20 @@ VertexingUtils::FCCAnalysesVertex  VertexFitter( int Primary,
 }
 
 
+VertexingUtils::FCCAnalysesVertex  VertexFitter_Tk( int Primary,
+                                                                        ROOT::VecOps::RVec<edm4hep::TrackState> tracks,
+                                                                        bool BeamSpotConstraint,
+                                                                        double bsc_sigmax, double bsc_sigmay, double bsc_sigmaz,
+                                                                        double bsc_x, double bsc_y, double bsc_z )  {
+
+  ROOT::VecOps::RVec<edm4hep::TrackState> dummy;
+  return VertexFitter_Tk( Primary, tracks, dummy, BeamSpotConstraint, bsc_sigmax, bsc_sigmay, bsc_sigmaz, bsc_x, bsc_y, bsc_z );
+}
+
 
 VertexingUtils::FCCAnalysesVertex  VertexFitter_Tk( int Primary,
 									ROOT::VecOps::RVec<edm4hep::TrackState> tracks,
+                                                                        const ROOT::VecOps::RVec<edm4hep::TrackState>& alltracks,
                                                                         bool BeamSpotConstraint,
                                                                         double bsc_sigmax, double bsc_sigmay, double bsc_sigmaz,
 									double bsc_x, double bsc_y, double bsc_z )  {
@@ -342,6 +354,20 @@ VertexingUtils::FCCAnalysesVertex  VertexFitter_Tk( int Primary,
   ROOT::VecOps::RVec<int> reco_ind;
   ROOT::VecOps::RVec<float> final_track_phases;
   ROOT::VecOps::RVec< TVector3 >  updated_track_momentum_at_vertex;
+
+  // if the collection of all tracks has been passed, keep trace of the indices of the tracks that are used to fit this vertex
+  if ( alltracks.size() > 0 ) {
+     for (int i=0; i < tracks.size(); i++) {     // the fitted tracks
+        edm4hep::TrackState tr1 = tracks[i];
+        for ( int j=0; j < alltracks.size(); j++) {     // the collection of all tracks
+           edm4hep::TrackState tr2 = alltracks[j];
+           if ( VertexingUtils::compare_Tracks( tr1, tr2 ) ) {
+              reco_ind.push_back( j ) ;
+              break;
+           }
+        }
+     }
+  }
 
   TheVertex.vertex = result;
   TheVertex.reco_chi2 = reco_chi2;

--- a/analyzers/dataframe/src/VertexingUtils.cc
+++ b/analyzers/dataframe/src/VertexingUtils.cc
@@ -75,6 +75,21 @@ get_nTracks( ROOT::VecOps::RVec<edm4hep::TrackState> tracks) {
   return nt;
 }
 
+bool compare_Tracks( const edm4hep::TrackState& tr1, const edm4hep::TrackState& tr2 ) {
+ if ( tr1.D0 == tr2.D0 &&
+      tr1.phi == tr2.phi &&
+      tr1.omega == tr2.omega &&
+      tr1.Z0 == tr2.Z0 && 
+      tr1.tanLambda == tr2.tanLambda &&
+      tr1.time == tr2.time &&
+      tr1.referencePoint.x == tr2.referencePoint.x && 
+      tr1.referencePoint.y == tr2.referencePoint.y &&  
+      tr1.referencePoint.z == tr2.referencePoint.z ) 
+   return true;
+ return false;
+}
+  
+
 
 TVectorD
 get_trackParam( edm4hep::TrackState & atrack) {
@@ -214,6 +229,28 @@ ROOT::VecOps::RVec<int> get_VertexNtrk( ROOT::VecOps::RVec<FCCAnalysesVertex> ve
 ROOT::VecOps::RVec<int> get_VertexRecoInd( FCCAnalysesVertex TheVertex ) {
   return TheVertex.reco_ind;
 }
+
+ROOT::VecOps::RVec<int> get_VertexRecoParticlesInd( FCCAnalysesVertex TheVertex,
+					            const ROOT::VecOps::RVec<edm4hep::ReconstructedParticleData>& reco ) {
+
+  ROOT::VecOps::RVec<int>  result;
+  ROOT::VecOps::RVec<int> indices_tracks = TheVertex.reco_ind;
+  for (int i=0; i < indices_tracks.size(); i++) {
+     int tk_index = indices_tracks[i];
+     for ( int j=0; j < reco.size(); j++) {
+        auto & p = reco[j];
+        if ( p.tracks_begin == p.tracks_end ) continue;  
+        if ( p.tracks_begin == tk_index ) {
+           result.push_back( j );
+           break;
+        }
+     }
+  }
+  return result;
+}
+
+
+
 
 TVectorD ParToACTS(TVectorD Par){
 


### PR DESCRIPTION
- vertexing updates: keep trace of the indices of the tracks (in the collection of tracks) that are fitted to a vertex (overload of VertexFitter_Tk for backward compatibility)
- subsequent changes in VertexFinderLCFIPlus
- method in VertexingUtils to retrieve the incdices of the fitted tracks, in the collection of RecoParticles
- bugfix of hasTRK in ReconstructedParticle2Track